### PR TITLE
First step to Rails 3 compatibility

### DIFF
--- a/lib/pg.rb
+++ b/lib/pg.rb
@@ -1,0 +1,4 @@
+# This is a compatibility layer for using the pure Ruby postgres-pr instead of
+# the C interface of postgres.
+
+require 'postgres-pr/postgres-compat'

--- a/lib/postgres-pr/pg-compat.rb
+++ b/lib/postgres-pr/pg-compat.rb
@@ -1,0 +1,174 @@
+# This is a compatibility layer for using the pure Ruby postgres-pr instead of
+# the C interface of postgres.
+
+require 'rexml/syncenumerator'
+require 'postgres-pr/connection'
+
+class PGconn
+  PQTRANS_IDLE    = 0 #(connection idle)
+  PQTRANS_INTRANS = 2 #(idle, within transaction block)
+  PQTRANS_INERROR = 3 #(idle, within failed transaction)
+  PQTRANS_UNKNOWN = 4 #(cannot determine status)
+
+  class << self
+    alias connect new
+  end
+
+  def initialize(host, port, options, tty, database, user, auth)
+    uri =
+    if host.nil?
+      nil
+    elsif host[0] != ?/
+      "tcp://#{ host }:#{ port }"
+    else
+      "unix:#{ host }/.s.PGSQL.#{ port }"
+    end
+    @host = host
+    @db = database
+    @user = user
+    @conn = PostgresPR::Connection.new(database, user, auth, uri)
+  end
+
+  def close
+    @conn.close
+  end
+
+  attr_reader :host, :db, :user
+
+  def query(sql)
+    PGresult.new(@conn.query(sql))
+  end
+
+  alias exec query
+
+  def transaction_status
+    @conn.transaction_status
+  end
+
+  def self.escape(str)
+    str.gsub("'","''").gsub("\\", "\\\\\\\\")
+  end
+
+  def escape(str)
+    self.class.escape(str)
+  end
+
+  def notice_processor
+    @conn.notice_processor
+  end
+
+  def notice_processor=(np)
+    @conn.notice_processor = np
+  end
+
+  def self.quote_ident(name)
+    %("#{name}")
+  end
+
+end
+
+class PGresult
+  include Enumerable
+
+  EMPTY_QUERY = 0
+  COMMAND_OK = 1
+  TUPLES_OK = 2
+  COPY_OUT = 3
+  COPY_IN = 4
+  BAD_RESPONSE = 5
+  NONFATAL_ERROR = 6
+  FATAL_ERROR = 7
+
+  def each(&block)
+    @result.each(&block)
+  end
+
+  def [](index)
+    @result[index]
+  end
+ 
+  def initialize(res)
+    @res = res
+    @fields = @res.fields.map {|f| f.name}
+    @result = []
+    @res.rows.each do |row|
+      @result << REXML::SyncEnumerator.new(fields, row).map {|name, value| [name, value]}
+    end
+  end
+
+  # TODO: status, getlength, cmdstatus
+
+  attr_reader :result, :fields
+
+  def num_tuples
+    @result.size
+  end
+
+  alias :ntuples :num_tuples
+
+  def num_fields
+    @fields.size
+  end
+
+  alias :nfields :num_fields
+
+  def fieldname(index)
+    @fields[index]
+  end
+
+  def fieldnum(name)
+    @fields.index(name)
+  end
+
+  def type(index)
+    # TODO: correct?
+    @res.fields[index].type_oid
+  end
+  
+  alias :ftype :type
+
+  def size(index)
+    raise
+    # TODO: correct?
+    @res.fields[index].typlen
+  end
+
+  def getvalue(tup_num, field_num)
+    @result[tup_num][field_num]
+  end
+
+  def status
+    if num_tuples > 0
+      TUPLES_OK
+    else
+      COMMAND_OK
+    end
+  end
+
+  def cmdstatus
+    @res.cmd_tag || ''
+  end
+
+  # free the result set
+  def clear
+    @res = @fields = @result = nil
+  end
+
+  # Returns the number of rows affected by the SQL command
+  def cmdtuples
+    case @res.cmd_tag
+    when nil 
+      return nil
+    when /^INSERT\s+(\d+)\s+(\d+)$/, /^(DELETE|UPDATE|MOVE|FETCH)\s+(\d+)$/
+      $2.to_i
+    else
+      nil
+    end
+  end
+  
+  alias :cmd_tuples :cmdtuples
+
+end
+
+class PGError < Exception
+end

--- a/lib/postgres-pr/postgres-compat.rb
+++ b/lib/postgres-pr/postgres-compat.rb
@@ -4,6 +4,11 @@
 require 'postgres-pr/connection'
 
 class PGconn
+  PQTRANS_IDLE    = 0 #(connection idle)
+  PQTRANS_INTRANS = 2 #(idle, within transaction block)
+  PQTRANS_INERROR = 3 #(idle, within failed transaction)
+  PQTRANS_UNKNOWN = 4 #(cannot determine status)
+
   class << self
     alias connect new
   end
@@ -41,6 +46,10 @@ class PGconn
 
   def self.escape(str)
     str.gsub("'","''").gsub("\\", "\\\\\\\\")
+  end
+
+  def escape(str)
+    self.class.escape(str)
   end
 
   def notice_processor
@@ -91,9 +100,13 @@ class PGresult
     @result.size
   end
 
+  alias :ntuples :num_tuples
+
   def num_fields
     @fields.size
   end
+
+  alias :nfields :num_fields
 
   def fieldname(index)
     @fields[index]
@@ -107,6 +120,8 @@ class PGresult
     # TODO: correct?
     @res.fields[index].type_oid
   end
+  
+  alias :ftype :type
 
   def size(index)
     raise
@@ -146,6 +161,8 @@ class PGresult
       nil
     end
   end
+  
+  alias :cmd_tuples :cmdtuples
 
 end
 


### PR DESCRIPTION
Added interface changes of the "pg" gem to the "postgres" gem compatibility layer.

Still the Rails 3 PostgreSQL adapter has problems with setting the client_min_messages for the connection and dislikes that PGresult enumerates rows as values Arrays and not Hashes consisting of column names and values.

I currently monkey-patched this in my Rails 3 adapter.