### PR TITLE
Specify US-ASCII encoding for bytea, fixing invalid multibyte escape on Jruby

### DIFF
--- a/lib/postgres-pr/typeconv/bytea.rb
+++ b/lib/postgres-pr/typeconv/bytea.rb
@@ -1,3 +1,5 @@
+# encoding: US-ASCII
+
 module Postgres::Conversion
 
   #


### PR DESCRIPTION
Closes https://github.com/mneumann/postgres-pr/issues/8